### PR TITLE
Unknown response improvements

### DIFF
--- a/lib/ipizza/provider.rb
+++ b/lib/ipizza/provider.rb
@@ -3,7 +3,7 @@ module Ipizza
 
     class << self
       def get(provider_name)
-        case provider_name.downcase
+        case provider_name.to_s.downcase
         when 'lhv'
           Ipizza::Provider::Lhv.new
         when 'swedbank', 'hp'
@@ -16,8 +16,6 @@ module Ipizza
           Ipizza::Provider::Krediidipank.new
         when 'nordea'
           Ipizza::Provider::Nordea.new
-        else
-          Ipizza::Provider::Base.new
         end
       end
     end

--- a/lib/ipizza/provider/base.rb
+++ b/lib/ipizza/provider/base.rb
@@ -77,7 +77,7 @@ module Ipizza::Provider
 
     def authentication_response(params)
       response = Ipizza::AuthenticationResponse.new(params)
-      response.verify(self.class.file_cert, self.class.encoding)
+      response.verify(self.class.file_cert)
       response
     end
 

--- a/lib/ipizza/util.rb
+++ b/lib/ipizza/util.rb
@@ -54,7 +54,7 @@ module Ipizza
       # Parameters val1, val2, value3 would be turned into "003val1003val2006value3".
       def mac_data_string(params, sign_param_order)
         (sign_param_order || []).inject('') do |memo, param|
-          val = params[param].to_s
+          val = params[param].to_s.strip
           memo << func_p(val) << val
           memo
         end

--- a/lib/ipizza/version.rb
+++ b/lib/ipizza/version.rb
@@ -1,3 +1,3 @@
 module Ipizza
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/spec/ipizza/provider_spec.rb
+++ b/spec/ipizza/provider_spec.rb
@@ -41,5 +41,9 @@ describe Ipizza::Provider do
     it 'returns nordea provider for "nordea" attribute' do
       Ipizza::Provider.get('nordea').should be_a(Ipizza::Provider::Nordea)
     end
+
+    it 'returns nothing for "unkn" attribute' do
+      Ipizza::Provider.get('unkn').should be_nil
+    end
   end
 end


### PR DESCRIPTION
Fixed issue when unknown provider is passed to provider.get() method.
    
* Nil value should be returned when unknown provider is passed to providers get method (general Base provider has no certificates loaded)
* Improved verification with missing key file and with blank response
* Improved MAC calculation with trailing spaces (MAC should be calculated for striped values)
