### PR TITLE
Support signing and verification algorithms provider based configuration

### DIFF
--- a/lib/ipizza/provider/base.rb
+++ b/lib/ipizza/provider/base.rb
@@ -4,7 +4,20 @@ module Ipizza::Provider
     SUPPORTED_ENCODINGS = %w(UTF-8 ISO-8859-1 WINDOWS-1257)
 
     class << self
-      attr_accessor :service_url, :return_url, :cancel_url, :file_key, :key_secret, :file_cert, :snd_id, :rec_id, :rec_acc, :rec_name, :encoding, :lang
+      attr_accessor :service_url,
+                    :return_url,
+                    :cancel_url,
+                    :file_key,
+                    :key_secret,
+                    :file_cert,
+                    :sign_algorithm,
+                    :verification_algorithm,
+                    :snd_id,
+                    :rec_id,
+                    :rec_acc,
+                    :rec_name,
+                    :encoding,
+                    :lang
     end
 
     def payment_request(payment, service_no = 1012)
@@ -40,7 +53,10 @@ module Ipizza::Provider
 
     def payment_response(params)
       response = Ipizza::PaymentResponse.new(params)
-      response.verify(self.class.file_cert)
+      response.verify(
+        self.class.file_cert,
+        self.class.verification_algorithm || Ipizza::Util::DEFAULT_HASH_ALGORITHM
+      )
       response
     end
 
@@ -77,7 +93,10 @@ module Ipizza::Provider
 
     def authentication_response(params)
       response = Ipizza::AuthenticationResponse.new(params)
-      response.verify(self.class.file_cert)
+      response.verify(
+        self.class.file_cert,
+        self.class.verification_algorithm || Ipizza::Util::DEFAULT_HASH_ALGORITHM
+      )
       response
     end
 

--- a/lib/ipizza/response.rb
+++ b/lib/ipizza/response.rb
@@ -14,9 +14,9 @@ class Ipizza::Response
     @params = params
   end
 
-  def verify(certificate_path)
+  def verify(certificate_path, hash_algorithm = Ipizza::Util::DEFAULT_HASH_ALGORITHM)
     mac_string = Ipizza::Util.mac_data_string(@params, PARAM_ORDER[@params['VK_SERVICE']])
 
-    @valid = Ipizza::Util.verify_signature(certificate_path, @params['VK_MAC'], mac_string)
+    @valid = Ipizza::Util.verify_signature(certificate_path, @params['VK_MAC'], mac_string, hash_algorithm)
   end
 end

--- a/spec/config/config.yml
+++ b/spec/config/config.yml
@@ -41,6 +41,8 @@ seb:
   key_secret: foobar
   encoding: UTF-8
   snd_id: sender
+  sign_algorithm: 'sha256'
+  verification_algorithm: 'sha256'
 
 luminor:
   service_url: https://banklink.luminor.ee/test

--- a/spec/config/plain_config.yml
+++ b/spec/config/plain_config.yml
@@ -11,3 +11,5 @@ swedbank:
 
 seb:
   service_url: https://www.seb.ee/banklink
+  sign_algorithm: 'sha256'
+  verification_algorithm: 'sha1'

--- a/spec/ipizza/config_spec.rb
+++ b/spec/ipizza/config_spec.rb
@@ -16,6 +16,8 @@ describe Ipizza::Config do
       Ipizza::Provider::Swedbank.encoding.should == 'UTF-8'
       
       Ipizza::Provider::Seb.service_url.should == 'https://www.seb.ee/banklink'
+      Ipizza::Provider::Seb.sign_algorithm.should == 'sha256'
+      Ipizza::Provider::Seb.verification_algorithm.should == 'sha1'
     end
   
     it 'should load certificates from path relative to configuration file' do

--- a/spec/ipizza/provider/seb_spec.rb
+++ b/spec/ipizza/provider/seb_spec.rb
@@ -45,7 +45,12 @@ describe Ipizza::Provider::Seb do
     }
 
     it 'should parse and verify the payment response from bank' do
-      signature = Ipizza::Util.sign(bank_key, nil, Ipizza::Util.mac_data_string(params, Ipizza::Response::PARAM_ORDER['1111']))
+      signature = Ipizza::Util.sign(
+        bank_key,
+        nil,
+        Ipizza::Util.mac_data_string(params, Ipizza::Response::PARAM_ORDER['1111']),
+        Ipizza::Provider::Seb.sign_algorithm
+      )
       Ipizza::Provider::Seb.new.payment_response(params.merge('VK_MAC' => signature)).should be_valid
     end
   end
@@ -82,7 +87,12 @@ describe Ipizza::Provider::Seb do
     }
 
     it 'should parse and verify the authentication response from bank' do
-      signature = Ipizza::Util.sign(bank_key, nil, Ipizza::Util.mac_data_string(params, Ipizza::Response::PARAM_ORDER['3012']))
+      signature = Ipizza::Util.sign(
+        bank_key,
+        nil,
+        Ipizza::Util.mac_data_string(params, Ipizza::Response::PARAM_ORDER['3012']),
+        Ipizza::Provider::Seb.sign_algorithm
+      )
       Ipizza::Provider::Seb.new.authentication_response(params.merge('VK_MAC' => signature)).should be_valid
     end
   end


### PR DESCRIPTION
Allow to override the default signing and verification algorithms per provider. This is needed for SEB as they are starting use SHA256 for signing and verification since 30 September 2023.

Added new class level configuration options for providers (default values are "sha1"):
```yaml
  sign_algorithm: 'sha256'
  verification_algorithm: 'sha256'
```
Closes #13