### PR TITLE
Support VK_VERSION override in providers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 Implements iPizza protocol to communicate with Estonian Banks.
 
-Gem implements support for iPizza services (`1011`, `1012`, `4011` and `4012`) that are supported by members of the Estonian Banking Association [since October 2014](http://pangaliit.ee/et/arveldused/pangalingi-spetsifikatsioon).
+Gem implements support for iPizza services (`1011`, `1012`, `4011` and `4012`) that are supported by members of the Estonian Banking Association [since October 2014](https://pangaliit.ee/arveldused/pangalingi-spetsifikatsioon).
 
 If you need to use this gem with old iPizza services implementations (`1001`, `1002`, `4001` and `4002`), use 1.0.0 version of this gem (NB! support for these services will end on 31 December 2015).
 
@@ -37,20 +37,24 @@ At any time, configuration can be modified with `Ipizza::Config.configure` block
       service_url: http://foo.bar/swedbank
       return_url: http://mycompany.com/store
       cancel_url: http://mycompany.com/cancel
-      
+
       # Your private key file path. Can be specified relatively
       # to YAML file
       file_key: ./certificates/my_private.key
-      
+
       # If your private key is protected with password,
       # provide it here
       key_secret: private_key_password
-      
+
       # Path to bank's public key file. Can be specified
       # relatively to YAML file
       file_cert: ./certificates/bank_public.crt
+      login: dealer
       snd_id: dealer
       encoding: UTF-8
+      sign_algorithm: sha256 # default is sha1
+      verification_algorithm: sha256 # default is sha1
+      vk_version: "009" # VK_VERSION. Default is "008"
 
 ## Payment requests
 
@@ -77,20 +81,17 @@ At any time, configuration can be modified with `Ipizza::Config.configure` block
 
 This library currently works with four Estonian Banks. Here are their respective interface specifications:
 
-* [Swedbank](https://www.swedbank.ee/business/cash/ecommerce/banklink/description?language=EST)
-* [SEB](http://www.seb.ee/ari/maksete-kogumine/maksete-kogumine-internetis/tehniline-spetsifikatsioon)
-* [Danske Bank](http://www.danskebank.ee/et/14732.html)
-* [Krediidipank](http://www.krediidipank.ee/business/settlements/bank-link/index.html)
-* [LHV Bank](https://www.lhv.ee/pangateenused/pangalink/)
-* [Nordea](http://www.nordea.ee/Teenused+%C3%A4rikliendile/Igap%C3%A4evapangandus/Maksete+kogumine/E-makse/1562142.html) (*uses SOLO protocol*)
+* [Swedbank](https://www.swedbank.ee/business/cash/ecommerce/support)
+* [SEB](https://www.seb.ee/en/business/daily-banking/bank-link)
+* [LHV Bank](https://partners.lhv.ee/en/banklink)
 
 # Helpful links
 
 * [pangalink.net](https://pangalink.net/et/info)
-* [Repository](http://github.com/priithaamer/ipizza)
-* [Issue tracker](http://github.com/priithaamer/ipizza/issues)
+* [Repository](https://github.com/Voog/ipizza)
+* [Issue tracker](https://github.com/Voog/ipizza/issues)
 
 # Authors
 
-* Thanks to [all contributors](https://github.com/priithaamer/ipizza/graphs/contributors)!
+* Thanks to [all contributors](https://github.com/Voog/ipizza/graphs/contributors)!
 * Tarmo Talu (Thanks for the 7-3-1 algorithm)

--- a/lib/ipizza/provider/base.rb
+++ b/lib/ipizza/provider/base.rb
@@ -1,6 +1,7 @@
 module Ipizza::Provider
   class Base
 
+    DEFAULT_VK_VERSION = '008'
     SUPPORTED_ENCODINGS = %w(UTF-8 ISO-8859-1 WINDOWS-1257)
 
     class << self
@@ -17,7 +18,8 @@ module Ipizza::Provider
                     :rec_acc,
                     :rec_name,
                     :encoding,
-                    :lang
+                    :lang,
+                    :vk_version
     end
 
     def payment_request(payment, service_no = 1012)
@@ -25,7 +27,7 @@ module Ipizza::Provider
       req.service_url = self.class.service_url
       req.sign_params = {
         'VK_SERVICE' => service_no,
-        'VK_VERSION' => '008',
+        'VK_VERSION' => vk_version,
         'VK_SND_ID' => self.class.snd_id,
         'VK_STAMP' => payment.stamp,
         'VK_AMOUNT' => sprintf('%.2f', payment.amount),
@@ -65,7 +67,7 @@ module Ipizza::Provider
       req.service_url = self.class.service_url
       req.sign_params = {
         'VK_SERVICE' => service_no,
-        'VK_VERSION' => '008',
+        'VK_VERSION' => vk_version,
         'VK_SND_ID' => self.class.snd_id,
         'VK_RETURN' => self.class.return_url,
         'VK_DATETIME' => Ipizza::Util.time_to_iso8601(Time.now),
@@ -104,6 +106,11 @@ module Ipizza::Provider
 
     def get_encoding(val)
       SUPPORTED_ENCODINGS.include?(val.to_s.upcase) ? val.to_s.upcase : 'UTF-8'
+    end
+
+    def vk_version
+      str = self.class.vk_version.to_s.strip
+      str.empty? ? DEFAULT_VK_VERSION : str
     end
   end
 end

--- a/spec/config/config.yml
+++ b/spec/config/config.yml
@@ -41,6 +41,7 @@ seb:
   key_secret: foobar
   encoding: UTF-8
   snd_id: sender
+  vk_version: '009'
   sign_algorithm: 'sha256'
   verification_algorithm: 'sha256'
 

--- a/spec/config/plain_config.yml
+++ b/spec/config/plain_config.yml
@@ -11,5 +11,6 @@ swedbank:
 
 seb:
   service_url: https://www.seb.ee/banklink
+  vk_version: '009'
   sign_algorithm: 'sha256'
   verification_algorithm: 'sha1'

--- a/spec/ipizza/config_spec.rb
+++ b/spec/ipizza/config_spec.rb
@@ -6,7 +6,7 @@ describe Ipizza::Config do
     before(:each) do
       Ipizza::Config.load_from_file(File.expand_path(File.dirname(__FILE__) + '/../config/plain_config.yml'))
     end
-    
+
     it 'should load configuration from yml file' do
       Ipizza::Provider::Swedbank.service_url.should == 'https://www.swedbank.ee/banklink'
       Ipizza::Provider::Swedbank.return_url.should == 'http://test.local/return'
@@ -14,28 +14,30 @@ describe Ipizza::Config do
       Ipizza::Provider::Swedbank.key_secret.should == 'foobar'
       Ipizza::Provider::Swedbank.snd_id.should == 'dealer'
       Ipizza::Provider::Swedbank.encoding.should == 'UTF-8'
-      
+
       Ipizza::Provider::Seb.service_url.should == 'https://www.seb.ee/banklink'
       Ipizza::Provider::Seb.sign_algorithm.should == 'sha256'
       Ipizza::Provider::Seb.verification_algorithm.should == 'sha1'
+      Ipizza::Provider::Seb.vk_version.should == '009'
+
     end
-  
+
     it 'should load certificates from path relative to configuration file' do
       Ipizza::Provider::Swedbank.file_key.should == File.expand_path(File.dirname(__FILE__) + '/../certificates/pangalink_swedbank_user_key.pem')
       Ipizza::Provider::Swedbank.file_cert.should == File.expand_path(File.dirname(__FILE__) + '/../certificates/pangalink_swedbank_bank_cert.pem')
     end
-    
+
     it 'should load certificates from absolute file paths' do
       cfg = {'swedbank' => YAML::load_file(File.expand_path(File.dirname(__FILE__) + '/../config/config.yml'))['swedbank']}
       cfg['swedbank']['file_key'] = File.expand_path(File.dirname(__FILE__) + '/../certificates/pangalink_swedbank_user_key.pem')
       cfg['swedbank']['file_cert'] = File.expand_path(File.dirname(__FILE__) + '/../certificates/pangalink_swedbank_bank_cert.pem')
-      
+
       Tempfile::open('config.yml') do |tmp|
         tmp << cfg.to_yaml
         tmp.flush
-        
+
         config = Ipizza::Config.load_from_file(File.expand_path(tmp.path))
-        
+
         Ipizza::Provider::Swedbank.file_key.should == File.expand_path(File.dirname(__FILE__) + '/../certificates/pangalink_swedbank_user_key.pem')
         Ipizza::Provider::Swedbank.file_cert.should == File.expand_path(File.dirname(__FILE__) + '/../certificates/pangalink_swedbank_bank_cert.pem')
       end
@@ -50,18 +52,18 @@ describe Ipizza::Config do
 
       Ipizza::Provider::Swedbank.service_url.should == 'http://foo.bar/swedbank'
     end
-    
+
     it 'should raise an error if configuration parameter does not exist' do
       lambda { Ipizza::Config.configure { |c| c.swedbank_unknown_attr = 'foo' } }.should raise_error
       lambda { Ipizza::Config.configure { |c| c.spermbank_service_url = 'foo' } }.should raise_error
     end
-    
+
     it 'loads certificates from directory specified by certs_root' do
       Ipizza::Config.configure do |c|
         c.certs_root = File.expand_path(File.dirname(__FILE__) + '/../certificates')
         c.swedbank_file_cert = 'pangalink_seb_bank_cert.pem'
       end
-      
+
       Ipizza::Provider::Swedbank.file_cert.should == File.expand_path(File.dirname(__FILE__) + '/../certificates/pangalink_seb_bank_cert.pem')
     end
   end

--- a/spec/ipizza/provider/seb_spec.rb
+++ b/spec/ipizza/provider/seb_spec.rb
@@ -16,7 +16,7 @@ describe Ipizza::Provider::Seb do
       req = Ipizza::Provider::Seb.new.payment_request(payment)
       params = {
         'VK_SERVICE' => '1012',
-        'VK_VERSION' => '008',
+        'VK_VERSION' => '009',
         'VK_SND_ID' => Ipizza::Provider::Seb.snd_id,
         'VK_STAMP' => payment.stamp,
         'VK_AMOUNT' => sprintf('%.2f', payment.amount),
@@ -65,7 +65,7 @@ describe Ipizza::Provider::Seb do
       req = Ipizza::Provider::Seb.new.authentication_request
       params = {
         'VK_SERVICE' => '4011',
-        'VK_VERSION' => '008',
+        'VK_VERSION' => '009',
         'VK_SND_ID' => Ipizza::Provider::Seb.snd_id,
         'VK_RETURN' => Ipizza::Provider::Seb.return_url,
         'VK_DATETIME' => Ipizza::Util.time_to_iso8601(Time.now),

--- a/spec/ipizza/provider_spec.rb
+++ b/spec/ipizza/provider_spec.rb
@@ -50,4 +50,32 @@ describe Ipizza::Provider do
       Ipizza::Provider.get('unkn').should be_nil
     end
   end
+
+  describe 'VK_VERSION override' do
+    let(:payment) do
+      Ipizza::Payment.new(stamp: 1, amount: '1.00', refnum: 1, message: 'Msg', currency: 'EUR')
+    end
+
+    before do
+      # Reset any custom value potentially set by other specs
+      Ipizza::Provider::Swedbank.vk_version = nil
+    end
+
+    it 'defaults to 008 when not set' do
+      req = Ipizza::Provider::Swedbank.new.payment_request(payment)
+      req.sign_params['VK_VERSION'].should == '008'
+    end
+
+    it 'uses overridden static value' do
+      Ipizza::Provider::Swedbank.vk_version = '009'
+      req = Ipizza::Provider::Swedbank.new.payment_request(payment)
+      req.sign_params['VK_VERSION'].should == '009'
+    end
+
+    it 'falls back when blank string provided' do
+      Ipizza::Provider::Swedbank.vk_version = '  '
+      req = Ipizza::Provider::Swedbank.new.authentication_request
+      req.sign_params['VK_VERSION'].should == '008'
+    end
+  end
 end


### PR DESCRIPTION
Add new provider configuration option `vk_version` to allow overriding the VK_VERSION parameter in requests.

VK_VERSION defaults to "008" but can be set to new "009" version that is required by most banks.

Closes #16