### PR TITLE
Fix sign_algorithm configuration usage

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,8 +52,8 @@ At any time, configuration can be modified with `Ipizza::Config.configure` block
       login: dealer
       snd_id: dealer
       encoding: UTF-8
-      sign_algorithm: sha256 # default is sha1
-      verification_algorithm: sha256 # default is sha1
+      sign_algorithm: sha512 # default is sha1
+      verification_algorithm: sha512 # default is sha1
       vk_version: "009" # VK_VERSION. Default is "008"
 
 ## Payment requests

--- a/lib/ipizza/provider/base.rb
+++ b/lib/ipizza/provider/base.rb
@@ -49,7 +49,13 @@ module Ipizza::Provider
         'VK_LANG' => self.class.lang
       }
 
-      req.sign(self.class.file_key, self.class.key_secret, Ipizza::Request::PARAM_ORDER[service_no.to_s])
+      req.sign(
+        self.class.file_key,
+        self.class.key_secret,
+        Ipizza::Request::PARAM_ORDER[service_no.to_s],
+        Ipizza::Request::DEFAULT_MAC_PARAM,
+        self.class.sign_algorithm || Ipizza::Util::DEFAULT_HASH_ALGORITHM
+      )
       req
     end
 
@@ -89,7 +95,13 @@ module Ipizza::Provider
         'VK_LANG' => self.class.lang
       }
 
-      req.sign(self.class.file_key, self.class.key_secret, Ipizza::Request::PARAM_ORDER[service_no.to_s])
+      req.sign(
+        self.class.file_key,
+        self.class.key_secret,
+        Ipizza::Request::PARAM_ORDER[service_no.to_s],
+        Ipizza::Request::DEFAULT_MAC_PARAM,
+        self.class.sign_algorithm || Ipizza::Util::DEFAULT_HASH_ALGORITHM
+      )
       req
     end
 

--- a/lib/ipizza/request.rb
+++ b/lib/ipizza/request.rb
@@ -1,6 +1,8 @@
 module Ipizza
   class Request
 
+    DEFAULT_MAC_PARAM = 'VK_MAC'
+
     attr_accessor :extra_params
     attr_accessor :sign_params
     attr_accessor :service_url
@@ -12,9 +14,14 @@ module Ipizza
       '4012' => %w(VK_SERVICE VK_VERSION VK_SND_ID VK_REC_ID VK_NONCE VK_RETURN VK_DATETIME VK_RID)
     }
 
-    def sign(privkey_path, privkey_secret, order, mac_param = 'VK_MAC')
-      signature = Ipizza::Util.sign(privkey_path, privkey_secret, Ipizza::Util.mac_data_string(sign_params, order))
-      self.sign_params[mac_param] = signature
+    def sign(privkey_path, privkey_secret, order, mac_param = nil, hash_algorithm = nil)
+      signature = Ipizza::Util.sign(
+        privkey_path,
+        privkey_secret,
+        Ipizza::Util.mac_data_string(sign_params, order),
+        hash_algorithm || Ipizza::Util::DEFAULT_HASH_ALGORITHM
+      )
+      self.sign_params[mac_param || DEFAULT_MAC_PARAM] = signature
     end
 
     def request_params

--- a/spec/config/config.yml
+++ b/spec/config/config.yml
@@ -42,8 +42,8 @@ seb:
   encoding: UTF-8
   snd_id: sender
   vk_version: '009'
-  sign_algorithm: 'sha256'
-  verification_algorithm: 'sha256'
+  sign_algorithm: 'sha512'
+  verification_algorithm: 'sha512'
 
 luminor:
   service_url: https://banklink.luminor.ee/test

--- a/spec/config/plain_config.yml
+++ b/spec/config/plain_config.yml
@@ -12,5 +12,5 @@ swedbank:
 seb:
   service_url: https://www.seb.ee/banklink
   vk_version: '009'
-  sign_algorithm: 'sha256'
-  verification_algorithm: 'sha1'
+  sign_algorithm: 'sha512'
+  verification_algorithm: 'sha512'

--- a/spec/ipizza/config_spec.rb
+++ b/spec/ipizza/config_spec.rb
@@ -16,10 +16,9 @@ describe Ipizza::Config do
       Ipizza::Provider::Swedbank.encoding.should == 'UTF-8'
 
       Ipizza::Provider::Seb.service_url.should == 'https://www.seb.ee/banklink'
-      Ipizza::Provider::Seb.sign_algorithm.should == 'sha256'
-      Ipizza::Provider::Seb.verification_algorithm.should == 'sha1'
+      Ipizza::Provider::Seb.sign_algorithm.should == 'sha512'
+      Ipizza::Provider::Seb.verification_algorithm.should == 'sha512'
       Ipizza::Provider::Seb.vk_version.should == '009'
-
     end
 
     it 'should load certificates from path relative to configuration file' do

--- a/spec/ipizza/provider/seb_spec.rb
+++ b/spec/ipizza/provider/seb_spec.rb
@@ -27,7 +27,12 @@ describe Ipizza::Provider::Seb do
         'VK_CANCEL' => Ipizza::Provider::Seb.cancel_url,
         'VK_DATETIME' => Ipizza::Util.time_to_iso8601(Time.now)
       }
-      signature = Ipizza::Util.sign(Ipizza::Provider::Seb.file_key, Ipizza::Provider::Seb.key_secret, Ipizza::Util.mac_data_string(params, Ipizza::Request::PARAM_ORDER['1012']))
+      signature = Ipizza::Util.sign(
+        Ipizza::Provider::Seb.file_key,
+        Ipizza::Provider::Seb.key_secret,
+        Ipizza::Util.mac_data_string(params, Ipizza::Request::PARAM_ORDER['1012']),
+        Ipizza::Provider::Seb.sign_algorithm || Ipizza::Util::DEFAULT_HASH_ALGORITHM
+      )
       req.sign_params['VK_MAC'].should == signature
     end
   end
@@ -72,7 +77,12 @@ describe Ipizza::Provider::Seb do
         'VK_RID' => '',
         'VK_REPLY' => '3012'
       }
-      signature = Ipizza::Util.sign(Ipizza::Provider::Seb.file_key, Ipizza::Provider::Seb.key_secret, Ipizza::Util.mac_data_string(params, Ipizza::Request::PARAM_ORDER['4011']))
+      signature = Ipizza::Util.sign(
+        Ipizza::Provider::Seb.file_key,
+        Ipizza::Provider::Seb.key_secret,
+        Ipizza::Util.mac_data_string(params, Ipizza::Request::PARAM_ORDER['4011']),
+        Ipizza::Provider::Seb.sign_algorithm || Ipizza::Util::DEFAULT_HASH_ALGORITHM
+      )
       req.sign_params['VK_MAC'].should == signature
     end
   end


### PR DESCRIPTION
Fix issue where configuration param `sign_algorithm` was not being used in the signing process for the request (algorithm SHA-512 is required for ver '009').